### PR TITLE
General overhaul

### DIFF
--- a/phpunit.xml
+++ b/phpunit.xml
@@ -1,5 +1,6 @@
 <phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/4.5/phpunit.xsd">
+         xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/4.5/phpunit.xsd"
+         bootstrap="vendor/autoload.php">
     <testsuites>
         <testsuite name="Default">
             <directory suffix=".php">tests</directory>

--- a/src/AppConfiguration.php
+++ b/src/AppConfiguration.php
@@ -11,6 +11,8 @@
 
 namespace Fusonic\WebApp;
 
+use Fusonic\WebApp\Objects\Image;
+
 /**
  * Contains all data of a web application to create different assets and/or tags.
  *

--- a/src/AppConfiguration.php
+++ b/src/AppConfiguration.php
@@ -405,14 +405,6 @@ class AppConfiguration
             $image->setSrc($data["src"]);
         }
 
-        if (isset($data["density"])) {
-            $image->setDensity($data["density"]);
-        }
-
-        if (isset($data["background_color"])) {
-            $image->setBackgroundColor($data["background_color"]);
-        }
-
         if (isset($data["type"])) {
             $image->setType($data["type"]);
         }

--- a/src/AppConfiguration.php
+++ b/src/AppConfiguration.php
@@ -11,12 +11,15 @@
 
 namespace Fusonic\WebApp;
 
+use Fusonic\WebApp\Generators\ManifestGenerator;
 use Fusonic\WebApp\Objects\Image;
 
 /**
  * Contains all data of a web application to create different assets and/or tags.
  *
  * @package Fusonic\WebApp
+ *
+ * @see ManifestGenerator
  */
 final class AppConfiguration
 {

--- a/src/AppConfiguration.php
+++ b/src/AppConfiguration.php
@@ -12,6 +12,7 @@
 namespace Fusonic\WebApp;
 
 use Fusonic\WebApp\Generators\ManifestGenerator;
+use Fusonic\WebApp\Generators\TagGenerator;
 use Fusonic\WebApp\Objects\Image;
 
 /**
@@ -20,6 +21,7 @@ use Fusonic\WebApp\Objects\Image;
  * @package Fusonic\WebApp
  *
  * @see ManifestGenerator
+ * @see TagGenerator
  */
 final class AppConfiguration
 {
@@ -55,8 +57,6 @@ final class AppConfiguration
     private $themeColor;
 
     private $manifestUrl;
-
-    private $splashScreens = [ ];
 
     /**
      * Returns the manifest URL.
@@ -437,29 +437,6 @@ final class AppConfiguration
     }
 
     /**
-     * Returns an array of all application splash screens.
-     *
-     * @return  Image[]
-     */
-    public function getSplashScreens()
-    {
-        return $this->splashScreens;
-    }
-
-    /**
-     * Adds an application splash screen.
-     *
-     * @param   Image               $splashScreen
-     *
-     * @return  AppConfiguration
-     */
-    public function addSplashScreen(Image $splashScreen)
-    {
-        $this->splashScreens[] = $splashScreen;
-        return $this;
-    }
-
-    /**
      * Creates an instance of the {@link AppConfiguration} class based on the values in the provided manifest file. Use
      * the {@link fromManifest} method to use a JSON string as source.
      *
@@ -539,12 +516,6 @@ final class AppConfiguration
 
         if (isset($data["theme_color"])) {
             $app->setThemeColor($data["theme_color"]);
-        }
-
-        if (isset($data["splash_screens"])) {
-            foreach ($data["splash_screens"] as $splashScreen) {
-                $app->addSplashScreen(self::imageFromData($splashScreen));
-            }
         }
 
         return $app;

--- a/src/AppConfiguration.php
+++ b/src/AppConfiguration.php
@@ -43,6 +43,10 @@ final class AppConfiguration
     const ORIENTATION_PORTRAIT_PRIMARY = "portrait-primary";
     const ORIENTATION_PORTRAIT_SECONDARY = "portrait-secondary";
 
+    const PLATFORM_ANDROID = "android";
+    const PLATFORM_IOS = "ios";
+    const PLATFORM_WEB = "web";
+
     private $backgroundColor;
     private $description;
     private $direction;

--- a/src/Generators/ManifestGenerator.php
+++ b/src/Generators/ManifestGenerator.php
@@ -95,6 +95,10 @@ final class ManifestGenerator
             "src" => $image->getSrc(),
         ];
 
+        if (($platform = $image->getPlatform()) !== null) {
+            $data["platform"] = $platform;
+        }
+
         if (count($purpose = $image->getPurpose()) > 0) {
             $data["purpose"] = implode(" ", $purpose);
         }

--- a/src/Generators/ManifestGenerator.php
+++ b/src/Generators/ManifestGenerator.php
@@ -86,14 +86,6 @@ final class ManifestGenerator
             $manifest["theme_color"] = $themeColor;
         }
 
-        if (count($splashScreens = $configuration->getSplashScreens()) > 0) {
-            $manifest["splash_screens"] = [ ];
-
-            foreach ($splashScreens as $splashScreen) {
-                $manifest["splash_screens"][] = $this->getImageData($splashScreen);
-            }
-        }
-
         return $manifest;
     }
 

--- a/src/Generators/ManifestGenerator.php
+++ b/src/Generators/ManifestGenerator.php
@@ -9,7 +9,10 @@
  * file that was distributed with this source code.
  */
 
-namespace Fusonic\WebApp;
+namespace Fusonic\WebApp\Generators;
+
+use Fusonic\WebApp\AppConfiguration;
+use Fusonic\WebApp\Objects\Image;
 
 /**
  * Generates an app manifest according to the W3C specification "Manifest for a web application"

--- a/src/Generators/ManifestGenerator.php
+++ b/src/Generators/ManifestGenerator.php
@@ -15,25 +15,48 @@ use Fusonic\WebApp\AppConfiguration;
 use Fusonic\WebApp\Objects\Image;
 
 /**
- * Generates an app manifest according to the W3C specification "Manifest for a web application"
- * See http://www.w3.org/TR/appmanifest/
+ * Generates an app manifest according to the W3C specification "Web App Manifest".
  *
  * @package Fusonic\WebApp
+ *
+ * @see https://www.w3.org/TR/appmanifest/
  */
-class ManifestGenerator
+final class ManifestGenerator
 {
-    public function __construct()
-    { }
-
     /**
-     * Returns the manifest data as array.
+     * Returns the manifest data as an array.
      *
-     * @param AppConfiguration $configuration The configuration to create the manifest from.
-     * @return array
+     * @param   AppConfiguration    $configuration      The configuration to create the manifest from.
+     *
+     * @return  array
      */
     public function get(AppConfiguration $configuration)
     {
-        $manifest = [];
+        $manifest = [ ];
+
+        if (($backgroundColor = $configuration->getBackgroundColor()) !== null) {
+            $manifest["background_color"] = $backgroundColor;
+        }
+
+        if (($description = $configuration->getDescription()) !== null) {
+            $manifest["description"] = $description;
+        }
+
+        if (($direction = $configuration->getDirection()) !== null) {
+            $manifest["dir"] = $direction;
+        }
+
+        if (($display = $configuration->getDisplay()) !== null) {
+            $manifest["display"] = $display;
+        }
+
+        if (count($icons = $configuration->getIcons()) > 0) {
+            $manifest["icons"] = [ ];
+
+            foreach ($icons as $icon) {
+                $manifest["icons"][] = $this->getImageData($icon);
+            }
+        }
 
         if (($language = $configuration->getLanguage()) !== null) {
             $manifest["lang"] = $language;
@@ -43,38 +66,28 @@ class ManifestGenerator
             $manifest["name"] = $name;
         }
 
-        if (($shortName = $configuration->getShortName()) !== null) {
-            $manifest["short_name"] = $shortName;
+        if (($orientation = $configuration->getOrientation()) !== null) {
+            $manifest["orientation"] = $orientation;
         }
 
         if (($scope = $configuration->getScope()) !== null) {
             $manifest["scope"] = $scope;
         }
 
+        if (($shortName = $configuration->getShortName()) !== null) {
+            $manifest["short_name"] = $shortName;
+        }
+
         if (($startUrl = $configuration->getStartUrl()) !== null) {
             $manifest["start_url"] = $startUrl;
         }
 
-        if (($display = $configuration->getDisplay()) !== null) {
-            $manifest["display"] = $display;
+        if (($themeColor = $configuration->getThemeColor()) !== null) {
+            $manifest["theme_color"] = $themeColor;
         }
 
-        if (($orientation = $configuration->getOrientation()) !== null) {
-            $manifest["orientation"] = $orientation;
-        }
-
-        $icons = $configuration->getIcons();
-        if (count($icons) > 0) {
-            $manifest["icons"] = [];
-
-            foreach ($icons as $icon) {
-                $manifest["icons"][] = $this->getImageData($icon);
-            }
-        }
-
-        $splashScreens = $configuration->getIcons();
-        if (count($splashScreens) > 0) {
-            $manifest["splash_screens"] = [];
+        if (count($splashScreens = $configuration->getSplashScreens()) > 0) {
+            $manifest["splash_screens"] = [ ];
 
             foreach ($splashScreens as $splashScreen) {
                 $manifest["splash_screens"][] = $this->getImageData($splashScreen);
@@ -90,16 +103,24 @@ class ManifestGenerator
             "src" => $image->getSrc(),
         ];
 
+        if (count($purpose = $image->getPurpose()) > 0) {
+            $data["purpose"] = implode(" ", $purpose);
+        }
+
         if (($type = $image->getType()) !== null) {
             $data["type"] = $type;
         }
 
-        $sizes = [];
-        foreach ($image->getSizes() as $size) {
-            $sizes[] = $size[0] . "x" . $size[1];
-        }
-        if (count($sizes) > 0) {
-            $data["sizes"] = implode(" ", $sizes);
+        if (count($sizes = $image->getSizes()) > 0) {
+            $data["sizes"] = implode(
+                " ",
+                array_map(
+                    function (array $size) {
+                        return "{$size[0]}x{$size[1]}";
+                    },
+                    $sizes
+                )
+            );
         }
 
         return $data;

--- a/src/Generators/TagGenerator.php
+++ b/src/Generators/TagGenerator.php
@@ -12,6 +12,7 @@
 namespace Fusonic\WebApp\Generators;
 
 use Fusonic\WebApp\AppConfiguration;
+use Fusonic\WebApp\Objects\Image;
 
 /**
  * Generates meta/link tags.
@@ -162,19 +163,21 @@ final class TagGenerator
         // Icons
         // https://html.spec.whatwg.org/multipage/semantics.html#rel-icon
         foreach ($configuration->getIcons() as $icon) {
-            $sizes = array_map(
-                function (array $size) {
-                    return "{$size[0]}x{$size[1]}";
-                },
-                $icon->getSizes()
-            );
+            if (in_array($icon->getPlatform(), [ null, Image::PLATFORM_WEB ])) {
+                $sizes = array_map(
+                    function (array $size) {
+                        return "{$size[0]}x{$size[1]}";
+                    },
+                    $icon->getSizes()
+                );
 
-            $tags[] = [
-                "link",
-                "rel" => "icon",
-                "href" => $icon->getSrc(),
-                "sizes" => count($sizes) > 0 ? implode(" ", $sizes) : null,
-            ];
+                $tags[] = [
+                    "link",
+                    "rel" => "icon",
+                    "href" => $icon->getSrc(),
+                    "sizes" => count($sizes) > 0 ? implode(" ", $sizes) : null,
+                ];
+            }
         }
 
         return $tags;
@@ -204,19 +207,21 @@ final class TagGenerator
         // Icons
         // https://developer.apple.com/library/content/documentation/AppleApplications/Reference/SafariWebContent/ConfiguringWebApplications/ConfiguringWebApplications.html#//apple_ref/doc/uid/TP40002051-CH3-SW4
         foreach ($configuration->getIcons() as $icon) {
-            $sizes = array_map(
-                function (array $size) {
-                    return "{$size[0]}x{$size[1]}";
-                },
-                $icon->getSizes()
-            );
+            if (in_array($icon->getPlatform(), [ null, Image::PLATFORM_IOS ])) {
+                $sizes = array_map(
+                    function (array $size) {
+                        return "{$size[0]}x{$size[1]}";
+                    },
+                    $icon->getSizes()
+                );
 
-            $tags[] = [
-                "link",
-                "rel" => "apple-touch-icon",
-                "href" => $icon->getSrc(),
-                "sizes" => count($sizes) > 0 ? implode(" ", $sizes) : null,
-            ];
+                $tags[] = [
+                    "link",
+                    "rel" => "apple-touch-icon",
+                    "href" => $icon->getSrc(),
+                    "sizes" => count($sizes) > 0 ? implode(" ", $sizes) : null,
+                ];
+            }
         }
 
         // apple-mobile-web-app-capable

--- a/src/Generators/TagGenerator.php
+++ b/src/Generators/TagGenerator.php
@@ -9,9 +9,11 @@
  * file that was distributed with this source code.
  */
 
-namespace Fusonic\WebApp;
+namespace Fusonic\WebApp\Generators;
 
 use Fusonic\Linq\Linq;
+use Fusonic\WebApp\AppConfiguration;
+use Fusonic\WebApp\Objects\Image;
 
 /**
  * Generates various meta/link tags.

--- a/src/Generators/TagGenerator.php
+++ b/src/Generators/TagGenerator.php
@@ -23,27 +23,32 @@ use Fusonic\WebApp\AppConfiguration;
  */
 final class TagGenerator
 {
-    private $generateStandardTags = true;
-    private $generateLegacyStandardTags = true;
-    private $generateAppleSpecificTags = true;
-    private $generateMicrosoftSpecificTags = true;
-
     /**
      * Returns a string containing all meta/link tags.
      *
      * @param   AppConfiguration    $configuration      The configuration to create tags from.
      *
+     * @param   bool                $standardTags       Generate standards-compliant tags?
+     * @param   bool                $legacyTags         Generate tags for legacy browsers?
+     * @param   bool                $appleTags          Generate proprietary tags for iOS devices?
+     * @param   bool                $microsoftTags      Generate proprietary tags for Windows devices?
+     *
      * @return  string
      */
-    public function getTags(AppConfiguration $configuration)
-    {
+    public function getTags(
+        AppConfiguration $configuration,
+        $standardTags = true,
+        $legacyTags = true,
+        $appleTags = true,
+        $microsoftTags = true
+    ) {
         return implode(
             "\n",
             array_map(
                 function (array $tag) {
                     return $this->renderTag($tag);
                 },
-                $this->getData($configuration)
+                $this->getData($configuration, $standardTags, $legacyTags, $appleTags, $microsoftTags)
             )
         );
     }
@@ -98,16 +103,20 @@ final class TagGenerator
      * </code>
      *
      * @param   AppConfiguration    $configuration
+     * @param   bool                $standardTags
+     * @param   bool                $legacyTags
+     * @param   bool                $appleTags
+     * @param   bool                $microsoftTags
      *
      * @return  array
      */
-    private function getData(AppConfiguration $configuration)
+    private function getData(AppConfiguration $configuration, $standardTags, $legacyTags, $appleTags, $microsoftTags)
     {
         return array_merge(
-            $this->generateStandardTags ? $this->getStandardTags($configuration) : [ ],
-            $this->generateLegacyStandardTags ? $this->getLegacyStandardTags($configuration) : [ ],
-            $this->generateAppleSpecificTags ? $this->getAppleTags($configuration) : [ ],
-            $this->generateMicrosoftSpecificTags ? $this->getMicrosoftTags($configuration) : [ ]
+            $standardTags ? $this->getStandardTags($configuration) : [ ],
+            $legacyTags ? $this->getLegacyTags($configuration) : [ ],
+            $appleTags ? $this->getAppleTags($configuration) : [ ],
+            $microsoftTags ? $this->getMicrosoftTags($configuration) : [ ]
         );
     }
 
@@ -126,7 +135,7 @@ final class TagGenerator
         return $tags;
     }
 
-    private function getLegacyStandardTags(AppConfiguration $configuration)
+    private function getLegacyTags(AppConfiguration $configuration)
     {
         $tags = [ ];
 

--- a/src/Image.php
+++ b/src/Image.php
@@ -19,62 +19,12 @@ namespace Fusonic\WebApp;
  */
 class Image
 {
-    private $backgroundColor;
-    private $density;
     private $sizes = [];
     private $src;
     private $type;
 
     public function __construct()
     { }
-
-    /**
-     * Returns the background color or null if no value is set.
-     *
-     * @return string|null
-     */
-    public function getBackgroundColor()
-    {
-        return $this->backgroundColor;
-    }
-
-    /**
-     * Sets the background color to use for the image. Must be a CSS3 valid color or null.
-     *
-     * @param string|null $backgroundColor The background color to use.
-     */
-    public function setBackgroundColor($backgroundColor)
-    {
-        $this->backgroundColor = $backgroundColor;
-    }
-
-    /**
-     * Returns the pixel density or null if no value is set.
-     *
-     * @return float|null
-     */
-    public function getDensity()
-    {
-        return $this->density;
-    }
-
-    /**
-     * Sets the density of this image file. May be null.
-     *
-     * @param float $density The density of this image file.
-     */
-    public function setDensity($density)
-    {
-        if ($density !== null) {
-            if (!filter_var($density, FILTER_SANITIZE_NUMBER_FLOAT)) {
-                throw new \InvalidArgumentException("Density must be a float.");
-            } else if ($density <= 0) {
-                throw new \InvalidArgumentException("Density must be greater than 0.");
-            }
-        }
-
-        $this->density = (float)$density;
-    }
 
     /**
      * Returns the src of the file or null if no value is set.

--- a/src/ManifestGenerator.php
+++ b/src/ManifestGenerator.php
@@ -91,14 +91,6 @@ class ManifestGenerator
             $data["type"] = $type;
         }
 
-        if (($density = $image->getDensity()) !== null) {
-            $data["density"] = $density;
-        }
-
-        if (($backgroundColor = $image->getBackgroundColor()) !== null) {
-            $data["background_color"] = $backgroundColor;
-        }
-
         $sizes = [];
         foreach ($image->getSizes() as $size) {
             $sizes[] = $size[0] . "x" . $size[1];

--- a/src/Members/PlatformTrait.php
+++ b/src/Members/PlatformTrait.php
@@ -1,0 +1,51 @@
+<?php
+
+/*
+ * This file is part of the fusonic/webapp package.
+ *
+ * (c) Fusonic GmbH <office@fusonic.net>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Fusonic\WebApp\Members;
+
+/**
+ * Adds support for the `platform` member.
+ *
+ * <p>
+ * There is no official list of possible values. However, the Web Platform Working Group maintains a list of known
+ * platform values {@link https://github.com/w3c/manifest/wiki/Platforms in their wiki}.
+ *
+ * @package Fusonic\WebApp
+ *
+ * @see https://www.w3.org/TR/appmanifest/#platform-member
+ */
+trait PlatformTrait
+{
+    private $platform;
+
+    /**
+     * Returns the intended target platform for this object.
+     *
+     * @return  string|null
+     */
+    public function getPlatform()
+    {
+        return $this->platform;
+    }
+
+    /**
+     * Sets the intended target platform for this object.
+     *
+     * @param   string              $platform
+     *
+     * @return  $this
+     */
+    public function setPlatform($platform)
+    {
+        $this->platform = $platform;
+        return $this;
+    }
+}

--- a/src/Objects/Image.php
+++ b/src/Objects/Image.php
@@ -11,6 +11,8 @@
 
 namespace Fusonic\WebApp\Objects;
 
+use Fusonic\WebApp\Members\PlatformTrait;
+
 /**
  * Represents an <b>image object</b>.
  *
@@ -20,6 +22,8 @@ namespace Fusonic\WebApp\Objects;
  */
 final class Image
 {
+    use PlatformTrait;
+
     const PURPOSE_BADGE = "badge";
     const PURPOSE_ANY = "any";
 

--- a/src/Objects/Image.php
+++ b/src/Objects/Image.php
@@ -9,7 +9,7 @@
  * file that was distributed with this source code.
  */
 
-namespace Fusonic\WebApp;
+namespace Fusonic\WebApp\Objects;
 
 /**
  * Defines an image according to the W3C specification "Manifest for a web application".

--- a/src/Objects/Image.php
+++ b/src/Objects/Image.php
@@ -12,68 +12,66 @@
 namespace Fusonic\WebApp\Objects;
 
 /**
- * Defines an image according to the W3C specification "Manifest for a web application".
- * See http://www.w3.org/TR/appmanifest/#image-object-and-its-members
+ * Represents an <b>image object</b>.
  *
  * @package Fusonic\WebApp
+ *
+ * @see https://www.w3.org/TR/appmanifest/#image-object-and-its-members
  */
-class Image
+final class Image
 {
-    private $sizes = [];
+    const PURPOSE_BADGE = "badge";
+    const PURPOSE_ANY = "any";
+
+    private $purpose = [ ];
+    private $sizes = [ ];
     private $src;
     private $type;
 
-    public function __construct()
-    { }
-
     /**
-     * Returns the src of the file or null if no value is set.
+     * Returns the image's intended purpose.
      *
-     * @return string|null
+     * @return  string[]
      */
-    public function getSrc()
+    public function getPurpose()
     {
-        return $this->src;
+        return array_values($this->purpose);
     }
 
     /**
-     * Sets the src of this image. May be null.
+     * Adds a purpose for this image.
      *
-     * @param string|null $src The src of the image.
-     */
-    public function setSrc($src)
-    {
-        $this->src = $src;
-    }
-
-    /**
-     * Returns the mime type of the file or null if no value is set.
+     * @param   string              $purpose            One of of Image::PURPOSE_* constants.
      *
-     * @return string|null
-     */
-    public function getType()
-    {
-        return $this->type;
-    }
-
-    /**
-     * Returns the mime type of this image. Must be a valid mime type or null.
+     * @return  Image
      *
-     * @param string|null $type The mime type of the image.
-     * @return $this
+     * @see https://www.w3.org/TR/appmanifest/#purpose-member
      */
-    public function setType($type)
+    public function addPurpose($purpose)
     {
-        $this->type = $type;
+        $this->purpose[$purpose] = $purpose;
         return $this;
+    }
+
+    /**
+     * Returns an array of sizes contained in this file.
+     *
+     * @return  array[]
+     */
+    public function getSizes()
+    {
+        return $this->sizes;
     }
 
     /**
      * Adds an additional size contained in this file.
      *
-     * @param int $width The width of the image.
-     * @param int $height The height of the image.
-     * @return $this;
+     * @param   int                 $width
+     * @param   int                 $height
+     *
+     * @return  Image
+     *
+     * @see https://www.w3.org/TR/appmanifest/#sizes-member
      */
     public function addSize($width, $height)
     {
@@ -82,12 +80,52 @@ class Image
     }
 
     /**
-     * Returns an array of sizes contained in this file.
+     * Returns the source path of this file.
      *
-     * @return array[]
+     * @return  string|null
      */
-    public function getSizes()
+    public function getSrc()
     {
-        return $this->sizes;
+        return $this->src;
+    }
+
+    /**
+     * Sets the source path of this file.
+     *
+     * @param   string              $src
+     *
+     * @return  Image
+     *
+     * @see https://www.w3.org/TR/appmanifest/#src-member
+     */
+    public function setSrc($src)
+    {
+        $this->src = $src;
+        return $this;
+    }
+
+    /**
+     * Returns the MIME type of this file.
+     *
+     * @return  string|null
+     */
+    public function getType()
+    {
+        return $this->type;
+    }
+
+    /**
+     * Sets the MIME type of this file.
+     *
+     * @param   string              $type
+     *
+     * @return  Image
+     *
+     * @see https://www.w3.org/TR/appmanifest/#type-member
+     */
+    public function setType($type)
+    {
+        $this->type = $type;
+        return $this;
     }
 }

--- a/tests/AppConfigurationTest.php
+++ b/tests/AppConfigurationTest.php
@@ -29,7 +29,6 @@ final class AppConfigurationTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals("icon/hd_hi", $app->getIcons()[2]->getSrc());
         $this->assertCount(1, $app->getIcons()[2]->getSizes());
         $this->assertEquals([128, 128], $app->getIcons()[2]->getSizes()[0]);
-        $this->assertEquals(2, $app->getIcons()[2]->getDensity());
 
         $this->assertCount(3, $app->getSplashScreens());
     }

--- a/tests/AppConfigurationTest.php
+++ b/tests/AppConfigurationTest.php
@@ -29,7 +29,5 @@ final class AppConfigurationTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals("icon/hd_hi", $app->getIcons()[2]->getSrc());
         $this->assertCount(1, $app->getIcons()[2]->getSizes());
         $this->assertEquals([128, 128], $app->getIcons()[2]->getSizes()[0]);
-
-        $this->assertCount(3, $app->getSplashScreens());
     }
 }

--- a/tests/Members/PlatformTraitTest.php
+++ b/tests/Members/PlatformTraitTest.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace Fusonic\WebApp\Members;
+
+use Fusonic\WebApp\AppConfiguration;
+
+final class PlatformTraitTest extends \PHPUnit_Framework_TestCase
+{
+    /**
+     * @covers \Fusonic\WebApp\Members\PlatformTrait::getPlatform
+     */
+    public function testInitialValueOfGetPlatform()
+    {
+        /** @var PlatformTrait $traitMock */
+        $traitMock = $this->getMockForTrait(PlatformTrait::class);
+
+        $this->assertNull($traitMock->getPlatform());
+    }
+
+    /**
+     * @covers \Fusonic\WebApp\Members\PlatformTrait::getPlatform
+     * @covers \Fusonic\WebApp\Members\PlatformTrait::setPlatform
+     */
+    public function testPlatformGetterAndSetter()
+    {
+        /** @var PlatformTrait $traitMock */
+        $traitMock = $this->getMockForTrait(PlatformTrait::class);
+        $traitMock
+            ->setPlatform(AppConfiguration::PLATFORM_ANDROID);
+
+        $this->assertSame(AppConfiguration::PLATFORM_ANDROID, $traitMock->getPlatform());
+
+        /** @var PlatformTrait $traitMock */
+        $traitMock = $this->getMockForTrait(PlatformTrait::class);
+        $traitMock
+            ->setPlatform(AppConfiguration::PLATFORM_IOS)
+            ->setPlatform(AppConfiguration::PLATFORM_WEB);
+
+        $this->assertSame(AppConfiguration::PLATFORM_WEB, $traitMock->getPlatform());
+    }
+}

--- a/tests/Objects/ImageTest.php
+++ b/tests/Objects/ImageTest.php
@@ -1,0 +1,120 @@
+<?php
+
+namespace Fusonic\WebApp\Objects;
+
+final class ImageTest extends \PHPUnit_Framework_TestCase
+{
+    /**
+     * @covers \Fusonic\WebApp\Objects\Image::getPurpose
+     */
+    public function testInitialValueOfGetPurpose()
+    {
+        $purpose = (new Image())->getPurpose();
+
+        $this->assertInternalType("array", $purpose);
+        $this->assertSame([ ], $purpose);
+    }
+
+    /**
+     * @covers \Fusonic\WebApp\Objects\Image::getPurpose
+     * @covers \Fusonic\WebApp\Objects\Image::addPurpose
+     */
+    public function testPurposeGetterAndSetter()
+    {
+        $image = (new Image())
+            ->addPurpose(Image::PURPOSE_ANY)
+            ->addPurpose(Image::PURPOSE_BADGE)
+            ->addPurpose(Image::PURPOSE_ANY)
+            ->addPurpose(Image::PURPOSE_BADGE);
+
+        // Per specs: "The purpose member is an unordered set of unique […] tokens […]"
+
+        $purpose = $image->getPurpose();
+
+        $this->assertSame(2, count($purpose));
+        $this->assertSame([ Image::PURPOSE_ANY, Image::PURPOSE_BADGE ], $purpose);
+    }
+
+    /**
+     * @covers \Fusonic\WebApp\Objects\Image::getSizes
+     */
+    public function testInitialValueOfGetSizes()
+    {
+        $sizes = (new Image())->getSizes();
+
+        $this->assertInternalType("array", $sizes);
+        $this->assertSame([ ], $sizes);
+    }
+
+    /**
+     * @covers \Fusonic\WebApp\Objects\Image::getSizes
+     * @covers \Fusonic\WebApp\Objects\Image::addSize
+     */
+    public function testSizeGetterAndSetter()
+    {
+        $image = (new Image())
+            ->addSize(100, 50)
+            ->addSize(200, 33)
+            ->addSize("100", 50)
+            ->addSize(128, 128.0);
+
+        // All sizes must be casted to integers.
+
+        $sizes = $image->getSizes();
+
+        $this->assertSame(4, count($sizes));
+        $this->assertSame([ [ 100, 50 ], [ 200, 33 ], [ 100, 50 ], [ 128, 128 ] ], $sizes);
+    }
+
+    /**
+     * @covers \Fusonic\WebApp\Objects\Image::getSrc
+     */
+    public function testInitialValueOfGetSrc()
+    {
+        $this->assertNull((new Image())->getSrc());
+    }
+
+    /**
+     * @covers \Fusonic\WebApp\Objects\Image::getSrc
+     * @covers \Fusonic\WebApp\Objects\Image::setSrc
+     */
+    public function testSrcGetterAndSetter()
+    {
+        $image = (new Image())
+            ->setSrc("android-128.png");
+
+        $this->assertSame("android-128.png", $image->getSrc());
+
+        $image = (new Image())
+            ->setSrc("android-256.png")
+            ->setSrc("ios-256.png");
+
+        $this->assertSame("ios-256.png", $image->getSrc());
+    }
+
+    /**
+     * @covers \Fusonic\WebApp\Objects\Image::getType
+     */
+    public function testInitialValueOfGetType()
+    {
+        $this->assertNull((new Image())->getType());
+    }
+
+    /**
+     * @covers \Fusonic\WebApp\Objects\Image::getType
+     * @covers \Fusonic\WebApp\Objects\Image::setType
+     */
+    public function testTypeGetterAndSetter()
+    {
+        $image = (new Image())
+            ->setType("image/png");
+
+        $this->assertSame("image/png", $image->getType());
+
+        $image = (new Image())
+            ->setType("image/jpeg")
+            ->setType("image/svg");
+
+        $this->assertSame("image/svg", $image->getType());
+    }
+}


### PR DESCRIPTION
Closes #2, #3, #4, #5, and #13.

## Notable improvements include:

* Getters and setters have been reordered – alphabetically, if optional; on top if they MUST be called
* Getters before setters
* Added references to official documentation

## Notes:

* No official documentation is available for `apple-mobile-web-app-title`
* `msapplication-tooltip` has not been implemented; does not work on both desktop and mobile devices (tested with Windows 10 and a Surface Tablet)

## Changes:

* Short name will be used for `application-name` and `apple-mobile-web-app-title` across all platforms
* `apple-mobile-web-app-status-bar-style` is NOT an alternative to the theme color
* `apple-touch-startup-image` has been REMOVED as [it is completely broken since iOS 9](https://forums.developer.apple.com/thread/23924)
* Option to generate a `title` tag has been removed. It was not honored in any case, and therefore it is pointless to implement it in this library

## To discuss:

* ~~Should we also remove the splash screen functionality from `AppConfiguration`? Was only used to generate Apple-specific tags.~~ — **REMOVED**
* ~~Should we implement [`prefer_related_applications`](https://developer.mozilla.org/en-US/docs/Web/Manifest#prefer_related_applications)?~~ — see #12
* ~~Should we implement [`related_applications`](https://developer.mozilla.org/en-US/docs/Web/Manifest#related_applications)?~~ — see #11
* ~~Should we implement the [`platform` member](https://www.w3.org/TR/appmanifest/#platform-member)?~~ — see #13
* Why is the `format-detection` feature disabled on iOS?

## To do:

- [x] Implement getters and setters for `$generate[…]Tags` members in `TagGenerator`